### PR TITLE
cleanup & simplifications

### DIFF
--- a/src/AST.c
+++ b/src/AST.c
@@ -1,4 +1,3 @@
-#include<stdlib.h>
 #include "include/AST.h"
 
 

--- a/src/AST.c
+++ b/src/AST.c
@@ -1,36 +1,36 @@
+#include<stdlib.h>
 #include "include/AST.h"
-
 
 AST_T* init_ast(int type)
 {
     AST_T* ast = calloc(1, sizeof(struct AST_STRUCT));
     ast->type = type;
 
-    ast->scope = (void*) 0;
+    ast->scope = NULL;
 
     /* AST_VARIABLE_DEFINITION */
-    ast->variable_definition_variable_name = (void*) 0;
-    ast->variable_definition_value = (void*) 0;
+    ast->variable_definition_variable_name = NULL;
+    ast->variable_definition_value = NULL;
 
     /* AST_FUNCTION_DEFINITION */
-    ast->function_definition_body = (void*) 0;
-    ast->function_definition_name = (void*) 0;
-    ast->function_definition_args = (void*) 0;
+    ast->function_definition_body = NULL;
+    ast->function_definition_name = NULL;
+    ast->function_definition_args = NULL;
     ast->function_definition_args_size = 0;
 
     /* AST_VARIABLE */
-    ast->variable_name = (void*) 0;
+    ast->variable_name = NULL;
 
     /* AST_FUNCTION_CALL */
-    ast->function_call_name = (void*) 0;
-    ast->function_call_arguments = (void*) 0;
+    ast->function_call_name = NULL;
+    ast->function_call_arguments = NULL;
     ast->function_call_arguments_size = 0;
 
     /* AST_STRING */
-    ast->string_value = (void*) 0;
+    ast->string_value = NULL;
 
     /* AST_COMPOUND */
-    ast->compound_value = (void*) 0;
+    ast->compound_value = NULL;
     ast->compound_size = 0;
 
     return ast;

--- a/src/AST.c
+++ b/src/AST.c
@@ -1,37 +1,11 @@
 #include<stdlib.h>
 #include "include/AST.h"
 
+
 AST_T* init_ast(int type)
 {
     AST_T* ast = calloc(1, sizeof(struct AST_STRUCT));
     ast->type = type;
-
-    ast->scope = NULL;
-
-    /* AST_VARIABLE_DEFINITION */
-    ast->variable_definition_variable_name = NULL;
-    ast->variable_definition_value = NULL;
-
-    /* AST_FUNCTION_DEFINITION */
-    ast->function_definition_body = NULL;
-    ast->function_definition_name = NULL;
-    ast->function_definition_args = NULL;
-    ast->function_definition_args_size = 0;
-
-    /* AST_VARIABLE */
-    ast->variable_name = NULL;
-
-    /* AST_FUNCTION_CALL */
-    ast->function_call_name = NULL;
-    ast->function_call_arguments = NULL;
-    ast->function_call_arguments_size = 0;
-
-    /* AST_STRING */
-    ast->string_value = NULL;
-
-    /* AST_COMPOUND */
-    ast->compound_value = NULL;
-    ast->compound_size = 0;
 
     return ast;
 }

--- a/src/io.c
+++ b/src/io.c
@@ -2,10 +2,9 @@
 #include <stdlib.h>
 #include <stdio.h>
 
-
 char* get_file_contents(const char* filepath)
 {
-    char* buffer = 0;
+    char* buffer = NULL;
     long length;
 
     FILE* f = fopen(filepath, "rb");
@@ -16,10 +15,10 @@ char* get_file_contents(const char* filepath)
         length = ftell(f);
         fseek(f, 0, SEEK_SET);
 
-        buffer = calloc(length, length);
+        buffer = calloc(length, sizeof(char));
 
         if (buffer)
-            fread(buffer, 1, length, f);
+            fread(buffer, sizeof(char), length, f);
 
         fclose(f);
         return buffer;

--- a/src/io.c
+++ b/src/io.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 
+
 char* get_file_contents(const char* filepath)
 {
     char* buffer = NULL;

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -36,24 +36,22 @@ token_T* lexer_get_next_token(lexer_T* lexer)
 {
     while (lexer->c != '\0' && lexer->i < strlen(lexer->contents))
     {
-        if (lexer->c == ' ' || lexer->c == 10)
+        if (lexer->c == ' ' || lexer->c == '\n')
             lexer_skip_whitespace(lexer);
 
         if (isalnum(lexer->c))
             return lexer_collect_id(lexer);
 
-        if (lexer->c == '"')
-            return lexer_collect_string(lexer);
-
         switch (lexer->c)
         {
-            case '=': return lexer_advance_with_token(lexer, init_token(TOKEN_EQUALS, lexer_get_current_char_as_string(lexer))); break;
-            case ';': return lexer_advance_with_token(lexer, init_token(TOKEN_SEMI, lexer_get_current_char_as_string(lexer))); break;
-            case '(': return lexer_advance_with_token(lexer, init_token(TOKEN_LPAREN, lexer_get_current_char_as_string(lexer))); break;
-            case ')': return lexer_advance_with_token(lexer, init_token(TOKEN_RPAREN, lexer_get_current_char_as_string(lexer))); break;
-            case '{': return lexer_advance_with_token(lexer, init_token(TOKEN_LBRACE, lexer_get_current_char_as_string(lexer))); break;
-            case '}': return lexer_advance_with_token(lexer, init_token(TOKEN_RBRACE, lexer_get_current_char_as_string(lexer))); break;
-            case ',': return lexer_advance_with_token(lexer, init_token(TOKEN_COMMA, lexer_get_current_char_as_string(lexer))); break;
+            case '"': return lexer_collect_string(lexer);
+            case '=': return lexer_advance_with_token(lexer, init_token(TOKEN_EQUALS, lexer_get_current_char_as_string(lexer)));
+            case ';': return lexer_advance_with_token(lexer, init_token(TOKEN_SEMI, lexer_get_current_char_as_string(lexer)));
+            case '(': return lexer_advance_with_token(lexer, init_token(TOKEN_LPAREN, lexer_get_current_char_as_string(lexer)));
+            case ')': return lexer_advance_with_token(lexer, init_token(TOKEN_RPAREN, lexer_get_current_char_as_string(lexer)));
+            case '{': return lexer_advance_with_token(lexer, init_token(TOKEN_LBRACE, lexer_get_current_char_as_string(lexer)));
+            case '}': return lexer_advance_with_token(lexer, init_token(TOKEN_RBRACE, lexer_get_current_char_as_string(lexer)));
+            case ',': return lexer_advance_with_token(lexer, init_token(TOKEN_COMMA, lexer_get_current_char_as_string(lexer)));
         }
     }
 
@@ -65,7 +63,6 @@ token_T* lexer_collect_string(lexer_T* lexer)
     lexer_advance(lexer);
 
     char* value = calloc(1, sizeof(char));
-    value[0] = '\0';
 
     while (lexer->c != '"')
     {
@@ -84,7 +81,6 @@ token_T* lexer_collect_string(lexer_T* lexer)
 token_T* lexer_collect_id(lexer_T* lexer)
 {
     char* value = calloc(1, sizeof(char));
-    value[0] = '\0';
 
     while (isalnum(lexer->c))
     {
@@ -109,7 +105,6 @@ char* lexer_get_current_char_as_string(lexer_T* lexer)
 {
     char* str = calloc(2, sizeof(char));
     str[0] = lexer->c;
-    str[1] = '\0';
 
     return str;
 }

--- a/src/lexer.c
+++ b/src/lexer.c
@@ -9,7 +9,6 @@ lexer_T* init_lexer(char* contents)
 {
     lexer_T* lexer = calloc(1, sizeof(struct LEXER_STRUCT));
     lexer->contents = contents;
-    lexer->i = 0;
     lexer->c = contents[lexer->i];
 
     return lexer;
@@ -55,7 +54,7 @@ token_T* lexer_get_next_token(lexer_T* lexer)
         }
     }
 
-    return init_token(TOKEN_EOF, "\0");
+    return init_token(TOKEN_EOF, "");
 }
 
 token_T* lexer_collect_string(lexer_T* lexer)

--- a/src/parser.c
+++ b/src/parser.c
@@ -53,28 +53,18 @@ AST_T* parser_parse_statements(parser_T* parser, scope_T* scope)
 {
     AST_T* compound = init_ast(AST_COMPOUND);
     compound->scope = scope;
-    compound->compound_value = calloc(1, sizeof(struct AST_STRUCT*));
 
-    AST_T* ast_statement = parser_parse_statement(parser, scope);
-    ast_statement->scope = scope;
-    compound->compound_value[0] = ast_statement;
-    compound->compound_size += 1;
+    while(parser->current_token->type != TOKEN_EOF){
+        compound->compound_size += 1;
+        compound->compound_value = realloc(
+            compound->compound_value,
+            compound->compound_size * sizeof(struct AST_STRUCT*)
+        );
 
-    while (parser->current_token->type == TOKEN_SEMI)
-    {
+        compound->compound_value[compound->compound_size-1] = parser_parse_statement(parser, scope);
+        compound->compound_value[compound->compound_size-1]->scope = scope;
+
         parser_eat(parser, TOKEN_SEMI);
-
-        AST_T* ast_statement = parser_parse_statement(parser, scope);
-
-        if (ast_statement)
-        {
-            compound->compound_size += 1;
-            compound->compound_value = realloc(
-                compound->compound_value,
-                compound->compound_size * sizeof(struct AST_STRUCT*)
-            );
-            compound->compound_value[compound->compound_size-1] = ast_statement;
-        }
     }
 
     return compound;

--- a/src/parser.c
+++ b/src/parser.c
@@ -141,18 +141,10 @@ AST_T* parser_parse_function_definition(parser_T* parser, scope_T* scope)
 
     parser_eat(parser, TOKEN_ID); // function name
 
-    parser_eat(parser, TOKEN_LPAREN);
-
-    ast->function_definition_args =
-        calloc(1, sizeof(struct AST_STRUCT*));
-
-    AST_T* arg = parser_parse_variable(parser, scope);
-    ast->function_definition_args_size += 1;
-    ast->function_definition_args[ast->function_definition_args_size-1] = arg;
-
-    while (parser->current_token->type == TOKEN_COMMA)
+    while (parser->current_token->type == TOKEN_LPAREN || parser->current_token->type == TOKEN_COMMA)
     {
-        parser_eat(parser, TOKEN_COMMA);
+        // eat whatever is there, it has to be a LPAREN or a COMMA
+        parser_eat(parser, parser->current_token->type);
 
         ast->function_definition_args_size += 1;
 
@@ -162,8 +154,7 @@ AST_T* parser_parse_function_definition(parser_T* parser, scope_T* scope)
                     ast->function_definition_args_size * sizeof(struct AST_STRUCT*)
                    );
 
-        AST_T* arg = parser_parse_variable(parser, scope);
-        ast->function_definition_args[ast->function_definition_args_size-1] = arg;
+        ast->function_definition_args[ast->function_definition_args_size-1] = parser_parse_variable(parser, scope);
     }
 
     parser_eat(parser, TOKEN_RPAREN);

--- a/src/parser.c
+++ b/src/parser.c
@@ -54,12 +54,14 @@ AST_T* parser_parse_statements(parser_T* parser, scope_T* scope)
     AST_T* compound = init_ast(AST_COMPOUND);
     compound->scope = scope;
 
-    while(parser->current_token->type != TOKEN_EOF){
+    while (parser->current_token->type != TOKEN_EOF)
+    {
         compound->compound_size += 1;
-        compound->compound_value = realloc(
-            compound->compound_value,
-            compound->compound_size * sizeof(struct AST_STRUCT*)
-        );
+        compound->compound_value =
+            realloc(
+                    compound->compound_value,
+                    compound->compound_size * sizeof(struct AST_STRUCT*)
+                   );
 
         compound->compound_value[compound->compound_size-1] = parser_parse_statement(parser, scope);
         compound->compound_value[compound->compound_size-1]->scope = scope;
@@ -95,15 +97,17 @@ AST_T* parser_parse_function_call(parser_T* parser, scope_T* scope)
 
     function_call->function_call_name = parser->prev_token->value;
 
-    while(parser->current_token->type == TOKEN_LPAREN || parser->current_token->type == TOKEN_COMMA){
+    while (parser->current_token->type == TOKEN_LPAREN || parser->current_token->type == TOKEN_COMMA)
+    {
         // eat whatever is there, it has to be a LPAREN or a COMMA
         parser_eat(parser, parser->current_token->type);
 
         function_call->function_call_arguments_size += 1;
-        function_call->function_call_arguments = realloc(
-            function_call->function_call_arguments,
-            function_call->function_call_arguments_size * sizeof(struct AST_STRUCT*)
-        );
+        function_call->function_call_arguments =
+            realloc(
+                    function_call->function_call_arguments,
+                    function_call->function_call_arguments_size * sizeof(struct AST_STRUCT*)
+                   );
         function_call->function_call_arguments[function_call->function_call_arguments_size-1]=
             parser_parse_expr(parser, scope);
     }

--- a/src/parser.c
+++ b/src/parser.c
@@ -133,17 +133,14 @@ AST_T* parser_parse_function_call(parser_T* parser, scope_T* scope)
 
 AST_T* parser_parse_variable_definition(parser_T* parser, scope_T* scope)
 {
+    AST_T* variable_definition = init_ast(AST_VARIABLE_DEFINITION);
+    variable_definition->scope = scope;
+
     parser_eat(parser, TOKEN_ID); // var
-    char* variable_definition_variable_name = parser->current_token->value;
+    variable_definition->variable_definition_variable_name = parser->current_token->value;
     parser_eat(parser, TOKEN_ID); // var name
     parser_eat(parser, TOKEN_EQUALS);
-    AST_T* variable_definition_value = parser_parse_expr(parser, scope);
-
-    AST_T* variable_definition = init_ast(AST_VARIABLE_DEFINITION);
-    variable_definition->variable_definition_variable_name = variable_definition_variable_name;
-    variable_definition->variable_definition_value = variable_definition_value;
-
-    variable_definition->scope = scope;
+    variable_definition->variable_definition_value = parser_parse_expr(parser, scope);
 
     return variable_definition;
 }

--- a/src/parser.c
+++ b/src/parser.c
@@ -94,25 +94,18 @@ AST_T* parser_parse_function_call(parser_T* parser, scope_T* scope)
     AST_T* function_call = init_ast(AST_FUNCTION_CALL);
 
     function_call->function_call_name = parser->prev_token->value;
-    parser_eat(parser, TOKEN_LPAREN); 
 
-    function_call->function_call_arguments = calloc(1, sizeof(struct AST_STRUCT*));
+    while(parser->current_token->type == TOKEN_LPAREN || parser->current_token->type == TOKEN_COMMA){
+        // eat whatever is there, it has to be a LPAREN or a COMMA
+        parser_eat(parser, parser->current_token->type);
 
-    AST_T* ast_expr = parser_parse_expr(parser, scope);
-    function_call->function_call_arguments[0] = ast_expr;
-    function_call->function_call_arguments_size += 1;
-
-    while (parser->current_token->type == TOKEN_COMMA)
-    {
-        parser_eat(parser, TOKEN_COMMA);
-
-        AST_T* ast_expr = parser_parse_expr(parser, scope);
         function_call->function_call_arguments_size += 1;
         function_call->function_call_arguments = realloc(
             function_call->function_call_arguments,
             function_call->function_call_arguments_size * sizeof(struct AST_STRUCT*)
         );
-        function_call->function_call_arguments[function_call->function_call_arguments_size-1] = ast_expr;
+        function_call->function_call_arguments[function_call->function_call_arguments_size-1]=
+            parser_parse_expr(parser, scope);
     }
     parser_eat(parser, TOKEN_RPAREN);
 

--- a/src/scope.c
+++ b/src/scope.c
@@ -5,8 +5,6 @@
 scope_T* init_scope()
 {
     scope_T* scope = calloc(1, sizeof(struct SCOPE_STRUCT));
-    scope->function_definitions = (void*) 0;
-    scope->function_definitions_size = 0;
 
     return scope;
 }
@@ -15,7 +13,7 @@ AST_T* scope_add_function_definition(scope_T* scope, AST_T* fdef)
 {
     scope->function_definitions_size += 1;
 
-    if (scope->function_definitions == (void*)0)
+    if (scope->function_definitions == NULL)
     {
         scope->function_definitions = calloc(1, sizeof(struct AST_STRUCT*));
     }
@@ -46,5 +44,5 @@ AST_T* scope_get_function_definition(scope_T* scope, const char* fname)
         }
     }
 
-    return (void*)0;
+    return NULL;
 }

--- a/src/visitor.c
+++ b/src/visitor.c
@@ -33,24 +33,22 @@ AST_T* visitor_visit(visitor_T* visitor, AST_T* node)
 {
     switch (node->type)
     {
-        case AST_VARIABLE_DEFINITION: return visitor_visit_variable_definition(visitor, node); break;
-        case AST_FUNCTION_DEFINITION: return visitor_visit_function_definition(visitor, node); break;
-        case AST_VARIABLE: return visitor_visit_variable(visitor, node); break;
-        case AST_FUNCTION_CALL: return visitor_visit_function_call(visitor, node); break;
-        case AST_STRING: return visitor_visit_string(visitor, node); break;
-        case AST_COMPOUND: return visitor_visit_compound(visitor, node); break;
-        case AST_NOOP: return node; break;
+        case AST_VARIABLE_DEFINITION: return visitor_visit_variable_definition(visitor, node);
+        case AST_FUNCTION_DEFINITION: return visitor_visit_function_definition(visitor, node);
+        case AST_VARIABLE: return visitor_visit_variable(visitor, node);
+        case AST_FUNCTION_CALL: return visitor_visit_function_call(visitor, node);
+        case AST_STRING: return visitor_visit_string(visitor, node);
+        case AST_COMPOUND: return visitor_visit_compound(visitor, node);
+        case AST_NOOP: return node;
     }
 
     printf("Uncaught statement of type `%d`\n", node->type);
     exit(1);
-
-    return init_ast(AST_NOOP);
 }
 
 AST_T* visitor_visit_variable_definition(visitor_T* visitor, AST_T* node)
 {
-    if (visitor->variable_definitions == (void*) 0)
+    if (visitor->variable_definitions == NULL)
     {
         visitor->variable_definitions = calloc(1, sizeof(struct AST_STRUCT*));
         visitor->variable_definitions[0] = node;


### PR DESCRIPTION
I cleaned up the following things wherever I found them:
* replaced `(void*)0` and similar things with `NULL` (*What is that cast to `void*` supposed to do?*)
* `calloc` already sets the allocated memory to zero, no need to do it again
* replaced magic numbers with character constants
* removed unnecessary `break`s after `return`s in switch statements
* removed dead code (in `visitor_visit`)

### additional notes
in `io.c`: I am pretty sure the allocation of the buffer was incorrect. I watched some of the videos, and noticed that it was written like that originally. I assume it was a mistake.

in `lexer.c`: I incorporated the string parsing into the switch statement. You hinted at doing that in the video, but did not do it.    
also: You will probably have to change the `isalnum` in l. 42 to `isalpha` when you implement numbers

in `parser.c`: There are multiple constructs like a function call, that can take a variable number of arguments. But in all cases I found, the first argument was parsed separately. I changed the `while` loops to also handle the first arguments.